### PR TITLE
Add RagTune - RAG retrieval debugging CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ These tools can assist in evaluating the performance of your RAG system, from tr
 - **[LangSmith](https://docs.smith.langchain.com/)**: A platform for building production-grade LLM applications, allows you to closely monitor and evaluate your application.
 - **[Hugging Face Evaluate](https://github.com/huggingface/evaluate)**: Tool for computing metrics like BLEU and ROUGE to assess text quality.
 - **[Weights & Biases](https://wandb.ai/wandb-japan/rag-hands-on/reports/Step-for-developing-and-evaluating-RAG-application-with-W-B--Vmlldzo1NzU4OTAx)**: Tracks experiments, logs metrics, and visualizes performance.
+- **[RagTune](https://github.com/metawake/ragtune/)**: CLI tool for debugging and benchmarking RAG retrieval—like EXPLAIN ANALYZE for your retrieval layer.
 
 ## 💾 Databases
 


### PR DESCRIPTION
RagTune is a CLI tool for debugging and benchmarking RAG retrieval pipelines.

- Debug single queries with score breakdowns
- Batch evaluation with recall/MRR metrics
- CI/CD quality gates

https://github.com/metawake/ragtune