### PR TITLE
Add Agentset to RAG frameworks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ Processing: A Survey**
   *CocoIndex is an open-source ETL framework to index data for AI, such as RAG; with realtime incremental updates and support custom logic like lego.*  
   [`Website`](https://cocoindex.io/)
 
+- **Agentset**  
+  *Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.*  
+  [`Website`](https://agentset.ai/) [`GitHub`](https://github.com/agentset-ai/agentset)
+
 ## Other Collections
 
 - [Awesome LLM RAG](https://github.com/jxzhangjhu/Awesome-LLM-RAG)


### PR DESCRIPTION
This PR adds Agentset to the RAG frameworks section.

Agentset is an open-source production-ready RAG infrastructure with built-in agentic reasoning, hybrid search, and multimodal support.

- Link verified and working: https://agentset.ai
- Description is accurate and concise
- Content fits the frameworks section
- Added at the end of the list per contribution guidelines