### PR TITLE
Add kreuzberg

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Mastra](https://github.com/mastra-ai/mastra): Typescript framework for building AI applications.
 - [Letta](https://github.com/letta-ai/letta): Open source framework for building stateful LLM applications.
 - [Flowise](https://github.com/FlowiseAI/Flowise): Drag & drop UI to build customized LLM flows.
+- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg): Polyglot document intelligence library (Rust core with Python, TypeScript, Go bindings) that extracts text, tables, and metadata from 62+ document formats for RAG ingestion pipelines.
 - [Swiftide](https://github.com/bosun-ai/swiftide): Rust framework for building modular, streaming LLM applications.
 - [CocoIndex](https://github.com/cocoindex-io/cocoindex): ETL framework to index data for AI, such as RAG; with realtime incremental updates.
 - [Pathway](https://github.com/pathwaycom/pathway/): Performant open-source Python ETL framework with Rust runtime, supporting 300+ data sources.


### PR DESCRIPTION
Adds [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) to the Frameworks that Facilitate RAG section.

Kreuzberg is a polyglot document intelligence library with a Rust core and bindings for Python, TypeScript, and Go. It extracts text, tables, and metadata from 62+ document formats, making it well-suited for the document ingestion and preprocessing stage of RAG pipelines.