### PR TITLE
Add Opik to RAG evaluation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Response evaluation in RAG solutions involves assessing the quality of language 
 These tools can assist in evaluating the performance of your RAG system, from tracking user feedback to logging query interactions and comparing multiple evaluation metrics over time.
 
 - **[LangFuse](https://github.com/langfuse/langfuse)**: Open-source tool for tracking LLM metrics, observability, and prompt management.
+- **[Opik](https://github.com/comet-ml/opik)**: Open-source platform for LLM observability, evaluations, and prompt optimization.
 - **[Ragas](https://docs.ragas.io/en/stable/)**: Framework that helps evaluate RAG pipelines.
 - **[LangSmith](https://docs.smith.langchain.com/)**: A platform for building production-grade LLM applications, allows you to closely monitor and evaluate your application.
 - **[Hugging Face Evaluate](https://github.com/huggingface/evaluate)**: Tool for computing metrics like BLEU and ROUGE to assess text quality.


### PR DESCRIPTION
## Summary
- add Opik to the relevant observability/evaluation section
- keep formatting consistent with the existing list structure

Opik: open-source platform for LLM observability, evaluations, and prompt optimization.