### PR TITLE
Add BGPT MCP to Frameworks that Facilitate RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 
 ## 🧰 Frameworks that Facilitate RAG
 
+- [BGPT MCP](https://github.com/connerlambden/bgpt-mcp): MCP server for searching scientific papers with structured experimental data extracted from full-text studies. Serves as a retrieval source for RAG pipelines that need evidence-grounded scientific knowledge.
 - [Haystack](https://github.com/deepset-ai/haystack): LLM orchestration framework to build customizable, production-ready LLM applications.
 - [LangChain](https://python.langchain.com/docs/modules/data_connection/): An all-purpose framework for working with LLMs.
 - [Semantic Kernel](https://github.com/microsoft/semantic-kernel): An SDK from Microsoft for developing Generative AI applications.


### PR DESCRIPTION
Adds BGPT MCP to the Frameworks section. BGPT is an MCP server for searching scientific papers with structured experimental data extracted from full-text studies. It serves as a retrieval source for RAG pipelines that need evidence-grounded scientific knowledge, returning 25+ structured fields per paper.

- **Website:** https://bgpt.pro/mcp
- **GitHub:** https://github.com/connerlambden/bgpt-mcp