### PR TITLE
Add FoJin — RAG application for Buddhist text Q&A

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Pathway AI Pipelines](https://github.com/pathwaycom/llm-app/): A production-ready RAG framework supporting real-time indexing, retrieval, and change tracking across diverse data sources.
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
+- [FoJin](https://github.com/xr843/fojin): Open-source Buddhist text platform with RAG-based Q&A over 11M characters of canonical texts. Dual retrieval (vector + keyword) with citation-grounded answers. Built with FastAPI, PostgreSQL pgvector, and Dify.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
## Summary

This PR adds [FoJin](https://github.com/xr843/fojin) to the "Frameworks that Facilitate RAG" section.

**FoJin** is an open-source Buddhist text research platform that uses RAG to enable Q&A over 11 million characters of canonical Buddhist texts (大藏经). Key RAG-related features:

- **Dual retrieval**: Combines vector similarity search (PostgreSQL pgvector) with keyword search (Elasticsearch) for hybrid retrieval, improving both precision and recall
- **Citation-grounded answers**: Every generated answer includes inline citations linking back to the exact source passages, ensuring transparency and verifiability
- **Dify integration**: Uses Dify's Dataset API as an additional retrieval source, enabling flexible knowledge base management
- **Domain-specific chunking**: Buddhist texts are chunked by structural units (经/卷/品) rather than fixed token counts, preserving semantic coherence

Tech stack: FastAPI + PostgreSQL (pgvector) + Elasticsearch + Redis + React, deployed with Docker Compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)