### PR TITLE
Add OpenDocuments to frameworks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Pathway AI Pipelines](https://github.com/pathwaycom/llm-app/): A production-ready RAG framework supporting real-time indexing, retrieval, and change tracking across diverse data sources.
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
+- [OpenDocuments](https://github.com/joungminsung/OpenDocuments): Self-hosted RAG platform that connects scattered org docs (GitHub, Notion, Drive, Confluence, S3) and answers questions with source citations.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
Hi, adding OpenDocuments to the frameworks section.

It's a self-hosted RAG platform that connects to GitHub, Notion, Google Drive, S3, Confluence, etc. and lets you ask questions in natural language with source citations. Supports local LLMs via Ollama, hybrid search (vector + keyword), and has a plugin system for custom parsers and connectors.

- GitHub: https://github.com/joungminsung/OpenDocuments
- License: MIT
- Language: TypeScript