### PR TITLE
Add Agent Brain to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Pathway AI Pipelines](https://github.com/pathwaycom/llm-app/): A production-ready RAG framework supporting real-time indexing, retrieval, and change tracking across diverse data sources.
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
+- [Agent Brain](https://github.com/kaderosio/agent-brain): 7-layer cognitive memory for AI agents with pgvector-based semantic retrieval, built on FastAPI and PostgreSQL. No LLM required.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
Adds [Agent Brain](https://github.com/kaderosio/agent-brain) to the Frameworks that Facilitate RAG section.

Agent Brain provides 7-layer cognitive memory for AI agents with pgvector-based semantic retrieval, built on FastAPI and PostgreSQL. Self-hostable, AGPLv3 licensed, no LLM required.