### PR TITLE
Add SwarmVault

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Pathway AI Pipelines](https://github.com/pathwaycom/llm-app/): A production-ready RAG framework supporting real-time indexing, retrieval, and change tracking across diverse data sources.
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
+- [SwarmVault](https://github.com/swarmclawai/swarmvault): Local-first RAG knowledge base compiler that turns raw research into a persistent markdown wiki, knowledge graph, and hybrid SQLite FTS + embeddings search index. Three-layer raw/wiki/schema architecture with contradiction detection, offline heuristic provider, Ollama and OpenAI-compatible embeddings, and a built-in MCP server.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
Adding SwarmVault to the Frameworks that Facilitate RAG section.

SwarmVault is a local-first RAG knowledge base compiler that turns raw research into a persistent markdown wiki, knowledge graph, and hybrid SQLite FTS + embeddings search index — a good fit alongside the other RAG frameworks in this section.

- SwarmVault: https://github.com/swarmclawai/swarmvault

License: MIT