### PR TITLE
Add pdfmux to Document Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Letta](https://github.com/letta-ai/letta): Open source framework for building stateful LLM applications.
 - [Flowise](https://github.com/FlowiseAI/Flowise): Drag & drop UI to build customized LLM flows.
 - [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg): Polyglot document intelligence library (Rust core with Python, TypeScript, Go bindings) that extracts text, tables, and metadata from 62+ document formats for RAG ingestion pipelines.
+- [pdfmux](https://github.com/NameetP/pdfmux): PDF-to-Markdown extraction library with per-page confidence scoring and self-healing fallback that re-extracts low-confidence pages automatically. Built-in MCP server and native LangChain + LlamaIndex loaders. #2 on opendataloader-bench (0.900).
 - [Swiftide](https://github.com/bosun-ai/swiftide): Rust framework for building modular, streaming LLM applications.
 - [CocoIndex](https://github.com/cocoindex-io/cocoindex): ETL framework to index data for AI, such as RAG; with realtime incremental updates.
 - [Pathway](https://github.com/pathwaycom/pathway/): Performant open-source Python ETL framework with Rust runtime, supporting 300+ data sources.


### PR DESCRIPTION
Adding [pdfmux](https://github.com/NameetP/pdfmux) under **Python Ecosystem for RAG → Document Processing**.

### What it is
A Python library and CLI that converts PDFs to Markdown by routing each page to the optimal backend — PyMuPDF for digital text, Docling for tables, RapidOCR for scans, Gemini Flash for hard pages — then attaches a per-page confidence score so retrieval pipelines can quarantine low-trust pages instead of feeding noise to the model.

### Why it fits this list
- **Built for RAG ingestion specifically**, not as a general PDF tool. The confidence score is the differentiator: it tells the retriever which chunks to trust.
- **First-party loaders** for both LangChain (`PdfmuxLoader`) and LlamaIndex (`PdfmuxReader`) — drop-in replacement for `PyPDFLoader` / `PyMuPDFLoader`.
- **Sits next to peers already in the section**: Unstructured, pdfplumber, markitdown — all PDF/document → text/markdown converters used in RAG pipelines.
- **Open source (MIT)**, on PyPI: `pip install pdfmux`. Actively maintained — v1.5.0 released April 2026 (6 releases since launch).
- **Benchmarked** on 1,422 pages across 11 real-world documents (10-Ks, S-1s, academic papers, legal opinions, FDA reports) with 100% confidence retained.

### Links
- Repo: https://github.com/NameetP/pdfmux
- Docs: https://pdfmux.com
- PyPI: https://pypi.org/project/pdfmux/
- LangChain integration: `pip install pdfmux[langchain]`
- LlamaIndex integration: `pip install pdfmux[llamaindex]`