### PR TITLE
Add Not Human Search for agent tool discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [REFRAG](https://arxiv.org/pdf/2509.01092): Optimizes RAG decoding by compressing retrieved context into embeddings before generation, reducing latency while maintaining output quality.
 - [InstructRAG](https://github.com/weizhepei/InstructRAG): Enhances RAG systems through instruction-based fine-tuning using self-synthesized rationales to improve retrieval and generation quality. 
 
+## 🔍 Tool & Agent Discovery
+
+- [Not Human Search](https://nothumansearch.ai) - Agent-first search engine indexing 1,400+ tools with agentic readiness scores. RAG-friendly with llms.txt, OpenAPI spec, and MCP server for tool discovery.
+
 ## 🧰 Frameworks that Facilitate RAG
 
 - [Haystack](https://github.com/deepset-ai/haystack): LLM orchestration framework to build customizable, production-ready LLM applications.


### PR DESCRIPTION
## What is Not Human Search?

[Not Human Search](https://nothumansearch.ai) is an agent-first search engine that indexes 1,400+ tools and services with agentic readiness scores.

**Why it fits this list:**
- RAG-friendly: provides llms.txt, OpenAPI spec, and structured data that RAG systems can consume directly
- MCP server for tool discovery - agents can search for and evaluate tools programmatically
- Agentic readiness scoring helps RAG pipelines identify which tools have the best structured data for retrieval
- Solves the "tool discovery" problem for agentic RAG systems that need to find and integrate external tools

**Placement:** Added as a new "Tool & Agent Discovery" section, as it provides a specialized retrieval capability that complements the existing RAG frameworks and techniques in the list.

**Website:** https://nothumansearch.ai