### PR TITLE
Add RAG Techniques repo and RAG Made Simple book to Python Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ RAG addresses a fundamental limitation of LLMs: their static knowledge cutoff an
 - [LlamaIndex RAG Tutorial](https://docs.llamaindex.ai/en/stable/getting_started/starter_example/): Getting started with LlamaIndex for RAG
 - [Haystack RAG Pipeline](https://docs.haystack.deepset.ai/docs/retrieval-augmented-generation): Building RAG pipelines with Haystack
 - [RAG Techniques](https://github.com/NirDiamant/RAG_Techniques): A comprehensive open-source collection of advanced Retrieval-Augmented Generation techniques as runnable Jupyter notebooks — chunking strategies, query transformations (HyDE, multi-query), hybrid search, reranking, self-query, parent-child retrieval, graph RAG, multi-hop retrieval, and evaluation
-- [RAG Made Simple](https://www.amazon.com/dp/B0D76734SZ): A visual guide book covering 22 RAG techniques with intuition, side-by-side comparisons of when each approach wins or fails, and original illustrations — the book companion to the *RAG Techniques* open-source repo
 
 #### Production & Best Practices
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ RAG addresses a fundamental limitation of LLMs: their static knowledge cutoff an
 - [LangChain RAG Tutorial](https://python.langchain.com/docs/use_cases/question_answering/): Comprehensive guide to building RAG applications
 - [LlamaIndex RAG Tutorial](https://docs.llamaindex.ai/en/stable/getting_started/starter_example/): Getting started with LlamaIndex for RAG
 - [Haystack RAG Pipeline](https://docs.haystack.deepset.ai/docs/retrieval-augmented-generation): Building RAG pipelines with Haystack
+- [RAG Techniques](https://github.com/NirDiamant/RAG_Techniques): A comprehensive open-source collection of advanced Retrieval-Augmented Generation techniques as runnable Jupyter notebooks — chunking strategies, query transformations (HyDE, multi-query), hybrid search, reranking, self-query, parent-child retrieval, graph RAG, multi-hop retrieval, and evaluation
+- [RAG Made Simple](https://www.amazon.com/dp/B0D76734SZ): A visual guide book covering 22 RAG techniques with intuition, side-by-side comparisons of when each approach wins or fails, and original illustrations — the book companion to the *RAG Techniques* open-source repo
 
 #### Production & Best Practices
 


### PR DESCRIPTION
Adds two entries to **Implementation Resources > Python Tutorials & Examples**:

### What's added

- **[RAG Techniques](https://github.com/NirDiamant/RAG_Techniques)** (27K+ ⭐) — comprehensive open-source collection of advanced Retrieval-Augmented Generation techniques as runnable Jupyter notebooks. Covers chunking strategies, query transformations (HyDE, multi-query, query decomposition), hybrid search, reranking, self-query, parent-child retrieval, graph RAG, multi-hop retrieval, evaluation, and production deployment patterns. Many techniques already referenced elsewhere in this awesome list (e.g. FLARE, Self-RAG, GraphRAG, Corrective RAG, Multimodal RAG) have hands-on implementations in this repo.
- **[RAG Made Simple](https://www.amazon.com/dp/B0D76734SZ)** — #1 Amazon Best Seller in Generative AI (April 2026). Visual guide book covering 22 RAG techniques with intuition, side-by-side comparisons of when each approach wins or fails, and original illustrations. Companion book to the *RAG Techniques* repo.

### Why these fit

- The Python Tutorials & Examples section currently lists LangChain, LlamaIndex, and Haystack tutorials. RAG Techniques complements those with a framework-agnostic, pattern-focused tutorial library.
- Both are maintained by [Nir Diamant](https://diamant-ai.com) (DiamantAI), who runs one of the most-followed open-source GenAI education programs (500K+ monthly developer reach).

### Format compliance

- Matches the existing bullet format `[Name](url): description`.
- No trailing period (matches surrounding style in this section).