### PR TITLE
Add supamem under Frameworks that Facilitate RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Pathway AI Pipelines](https://github.com/pathwaycom/llm-app/): A production-ready RAG framework supporting real-time indexing, retrieval, and change tracking across diverse data sources.
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
+- [supamem](https://github.com/dzmitrys-dev/supamem/): Persistent RAG-based memory for AI coding agents (Claude Code, Cursor, OpenCode); chunking + dense (minilm) + sparse (bm25) with RRF fusion via Qdrant.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
Adds [supamem](https://github.com/dzmitrys-dev/supamem/) — a persistent RAG-based memory layer for AI coding agents (Claude Code, Cursor, OpenCode).

## What it is (D-19 framing)

Persistent RAG-based memory for AI coding agents. supamem is a *memory layer*, not a general-purpose RAG framework or LangChain-style building blocks. It indexes a project's docs, ADRs, decisions, and past conversations once, then serves the right ~1–2 KB of context for the current prompt across sessions.

RAG techniques applied:

- **Chunking** — markdown-header-aware (preserves section semantics)
- **Dense retrieval** — `minilm` embeddings via fastembed
- **Sparse retrieval** — `bm25`
- **Fusion** — RRF (`tuned_hybrid` retrieval backend, the production default)
- **Storage** — Qdrant 1.10+ over HTTP

## Why it belongs on a RAG list

Most awesome-RAG entries are frameworks (LangChain, LlamaIndex, etc.) or research papers. supamem is the practical end of the spectrum: a fully-wired retrieval pipeline that any AI coding agent can pick up without writing glue code. It's a concrete *application* of RAG to the specific problem of agent memory.

## Canonical description

`supamem` is a single-binary CLI that wires up a production-grade memory layer for any AI coding assistant. Drop it into a fresh repo, run `supamem init`, and your agents instantly gain:

- 🔍 Semantic search over project notes, ADRs, decisions, and past conversations (hybrid sparse+dense retrieval)
- 🤖 MCP server that any compatible client (Claude Code, Cursor, OpenCode) can talk to
- 🪝 Per-client hooks that auto-load relevant memory at session start and on file edits
- 📊 Welford usage stats so you can see what memory is actually being recalled
- 🧪 Eval harness with a 33-query golden corpus to detect retrieval regressions

MIT-licensed, Python 3.12+, on PyPI: `pip install supamem`.

Battle-tested inside SoftChat (Phases 80.1–80.5) before being extracted into a standalone package. Bench result: **−78.5% tokens vs naive whole-doc retrieval at the same recall, p95 73 ms** end-to-end (33-query golden corpus).

## Per-list bullet formatting (for reviewer convenience)

- brandonhimpfen/awesome-rag (em-dash):
  `[supamem](https://github.com/dzmitrys-dev/supamem/) – Persistent RAG-based memory for AI coding agents (Claude Code, Cursor, OpenCode); chunking + dense (minilm) + sparse (bm25) with RRF fusion via Qdrant.`
- Danielskry/Awesome-RAG (colon, link-wrapped):
  `[supamem](https://github.com/dzmitrys-dev/supamem/): Persistent RAG-based memory for AI coding agents (Claude Code, Cursor, OpenCode); chunking + dense (minilm) + sparse (bm25) with RRF fusion via Qdrant.`
