### PR TITLE
Add Korean RAG SSOT Golden 50 dataset to Metrics & Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,12 @@ These tools can assist in evaluating the performance of your RAG system, from tr
 - **[Hugging Face Evaluate](https://github.com/huggingface/evaluate)**: Tool for computing metrics like BLEU and ROUGE to assess text quality.
 - **[Weights & Biases](https://wandb.ai/wandb-japan/rag-hands-on/reports/Step-for-developing-and-evaluating-RAG-application-with-W-B--Vmlldzo1NzU4OTAx)**: Tracks experiments, logs metrics, and visualizes performance.
 
+#### Datasets
+
+These public datasets are useful for benchmarking retrievers, rerankers, and end-to-end RAG pipelines.
+
+- **[Korean RAG SSOT Golden 50](https://huggingface.co/datasets/neogenesislab/korean-rag-ssot-golden-50)**: 50 hand-curated Korean retrieval-evaluation tasks across five operational categories (RAG architecture, agent ensembles, SSOT governance, Korean PII/security, fleet operations). Each item carries an `expected_source_type` (human / llm_output / external_citation / tool_log) so retrievers can be scored on provenance fidelity, not just lexical overlap. Recommended metrics include `recall_at_10`, `ndcg_at_10`, `credential_leak_rate`, and `injection_quarantine_recall`. Released under CC-BY-4.0.
+
 ## 💾 Databases
 
 Vector databases are critical components of RAG systems, providing efficient storage and similarity search capabilities for embeddings. The selection of an appropriate database depends on factors such as scale, latency requirements, deployment model (cloud vs. on-premises), and feature needs (hybrid search, filtering, etc.). The list below features database systems suitable for RAG applications:


### PR DESCRIPTION
Hi! Thanks for maintaining this list — it's been a useful map while building our own RAG pipeline.

## What this PR adds

A new `#### Datasets` subsection under `## 📊 Metrics & Evaluation`, with a single entry for the [Korean RAG SSOT Golden 50](https://huggingface.co/datasets/neogenesislab/korean-rag-ssot-golden-50).

## Why it fits this list

The list already covers evaluation **frameworks** (Ragas, LangFuse, etc.) but doesn't yet point to public **eval datasets** — that's the gap this entry tries to fill, with one well-scoped Korean-language entry rather than dumping a long list.

What's specific about this dataset:

- **Korean-language operational data** — 50 hand-curated tasks drawn from real RAG/agent operational documentation, not translated English benchmarks. Useful for teams that have to evaluate retrievers on Korean text without falling back to MS MARCO + machine translation.
- **Provenance-aware evaluation** — each task carries an `expected_source_type` field (`human` / `llm_output` / `external_citation` / `tool_log`). Retrievers can be scored on whether they correctly prioritize human-authored chunks over LLM-generated ones, which matters once an SSOT contains a mix of authored docs and synthetic/agent output.
- **Recommended metrics include security signals** — beyond `recall_at_10` and `ndcg_at_10`, the dataset card recommends `credential_leak_rate` (target 0.0) and `injection_quarantine_recall` (target 0.95). These are useful for teams that index sensitive/regulated content.
- **License: CC-BY-4.0** — usable for both research and commercial benchmarking with attribution.
- **Categories (5):** `rag_v2_design` (18), `quant_v11` (8), `ssot_governance` (12), `security_pii` (6), `operations` (6).

## Quick load

```python
from datasets import load_dataset
ds = load_dataset("neogenesislab/korean-rag-ssot-golden-50", split="train")
```

## Diff

One additive change: a new `#### Datasets` subsection (4 lines of section header/intro + 1 dataset bullet, 6 lines total). No existing entries were modified or reordered.

Happy to adjust wording, move the placement, or trim the description if you'd prefer something shorter — just let me know.