### PR TITLE
Add Thalamus to Frameworks that Facilitate RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
-- [Thalamus](https://github.com/msbel5/openclaw-thalamus): Cognitive routing layer for multi-agent crews on edge devices. 3-field packet handoff between agents, 9-namespace local vector store, Qwen3-Embedding-0.6B (1024d) on CPU via llama.cpp, optional Hailo NPU HEFs (Whisper/CLIP), FAISS RaBitQ codebook. Designed for Raspberry Pi 5; Node side runs anywhere. MCP server included.
+- [Thalamus](https://github.com/msbel5/openclaw-thalamus): Cognitive routing layer for multi-agent workflows on edge devices with MCP support.
 
 ## 🐍 Python Ecosystem for RAG
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
+- [Thalamus](https://github.com/msbel5/openclaw-thalamus): Cognitive routing layer for multi-agent crews on edge devices. 3-field packet handoff between agents, 9-namespace local vector store, Qwen3-Embedding-0.6B (1024d) on CPU via llama.cpp, optional Hailo NPU HEFs (Whisper/CLIP), FAISS RaBitQ codebook. Designed for Raspberry Pi 5; Node side runs anywhere. MCP server included.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
Adds [Thalamus](https://github.com/msbel5/openclaw-thalamus) to the *Frameworks that Facilitate RAG* section.

**What it is**: cognitive routing layer for multi-agent AI crews on edge devices (Raspberry Pi 5). 9-namespace local vector store with Qwen3-Embedding-0.6B Q4_0 GGUF (1024d) on CPU via llama.cpp. Optional Hailo-10H NPU HEFs for Whisper ASR and CLIP vision. FAISS RaBitQ codebook for concept compression.

**RAG-relevance**: the receiver agent calls `thalamus_search` on its inline_vector to retrieve only the relevant atoms from a packet, avoiding transcript paste between agents. Atom namespaces: code, audit, plan, memory, audio.raw, audio.text, image.raw, image.text, crossmodal.

**Verifiable**: raw measurement output (codebook gate, encoder warm latency, telemetry samples) paste-in verbatim in [BENCHMARKS.md](https://github.com/msbel5/openclaw-thalamus/blob/main/BENCHMARKS.md). MIT licensed, npm package `openclaw-thalamus`.