### PR TITLE
Response Quality & Safety: add Small-Rule Guardrails preprint + tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,11 @@ Ensuring high-quality, safe, and reliable responses is critical for production R
   - **Rate Limiting**: Implement rate limits and abuse detection to prevent systematic attacks
   - **Sandboxing**: Isolate LLM execution environments to limit potential damage from successful injections
 
+- **Small-Rule Guardrails (preprint + tools)**
+  - **[Preprint](https://doi.org/10.5281/zenodo.20057056)**: Small-Rule Guardrails for Retrieval-Augmented Generation: Prompt Injection and Vector Poisoning Checks. Compact engineering note on inspectable guardrails between retrieval and prompt construction.
+  - **[prompt-injection-shield](https://github.com/MukundaKatta/prompt-injection-shield)**: zero-dep JS scanner for instruction overrides, system-prompt impersonation, tool-call hijack, URL-based exfil, and secret patterns in retrieved text.
+  - **[vector-poison-score](https://github.com/MukundaKatta/vector-poison-score)**: zero-dep JS scorer for retrieved chunks (oversized chunks, secret-exfil patterns, suspicious link clusters).
+
 ## 📊 Metrics & Evaluation
 
 ### Similarity Metrics for Embeddings


### PR DESCRIPTION
Adding a small additions block under Prompt Injection Prevention. The preprint covers an inspectable, small-rule guardrail approach for the gap between retrieval and prompt construction; the two zero-dep npm libraries are the working code behind it.

- Preprint: Small-Rule Guardrails for Retrieval-Augmented Generation (Zenodo DOI 10.5281/zenodo.20057056, Figshare mirror 10.6084/m9.figshare.32193543)
- prompt-injection-shield (npm `@mukundakatta/prompt-injection-shield`)
- vector-poison-score (npm `@mukundakatta/vector-poison-score`)

Both libraries are MIT, zero runtime dependencies. Companion writeup: https://dev.to/mukundakatta/i-got-burned-by-prompt-injection-in-production-here-are-2-tiny-npm-libs-that-stopped-it-438i