### PR TITLE
Adds dlt (data load tool) to the Frameworks that Facilitate RAG section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
-- [data load tool](https://github.com/dlt-hub/dlt):  Open-source Python library for building reliable extract and load data pipelines with automatic schema handling and incremental, stateful loading. Useful for keeping RAG knowledge sources up to date before embedding and indexing.
 
 ## 🐍 Python Ecosystem for RAG
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
+- [data load tool](https://github.com/dlt-hub/dlt):  Open-source Python library for building reliable extract and load data pipelines with automatic schema handling and incremental, stateful loading. Useful for keeping RAG knowledge sources up to date before embedding and indexing.
 
 ## 🐍 Python Ecosystem for RAG
 

--- a/docs/python-ecosystem.md
+++ b/docs/python-ecosystem.md
@@ -82,6 +82,7 @@ Python is a dominant language for building RAG systems, offering a rich ecosyste
 - **[Pandas](https://pandas.pydata.org/)**: Data manipulation and analysis library for structured data
 - **[Polars](https://www.pola.rs/)**: Fast DataFrame library implemented in Rust with Python bindings
 - **[DuckDB](https://github.com/duckdb/duckdb)**: In-process analytical database with Python interface
+- **[data load tool](https://github.com/dlt-hub/dlt)**: Open-source Python library for building reliable extract and load data pipelines with automatic schema handling and incremental, stateful loading. Useful for keeping RAG knowledge sources up to date before embedding and indexing.
 
 #### Configuration & Environment
 


### PR DESCRIPTION
dlt is an open-source Python library for building reliable data ingestion pipelines with automatic schema handling and incremental loading. It's useful for keeping RAG knowledge sources up to date before embedding and indexing, and supports vector store destinations like LanceDB, Qdrant, and Weaviate.

Github: https://github.com/dlt-hub/dlt
Website: https://dlthub.com