### PR TITLE
Add grounding-ai to Frameworks that Facilitate RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
+- [grounding-ai](https://github.com/andyliszewski/grounding-ai): Local-first RAG pipeline. Ingests PDFs, EPUBs, and Word docs into a searchable index, queryable via an MCP server that returns chunks with exact page-and-section citations.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
Adds [grounding-ai](https://github.com/andyliszewski/grounding-ai) to the **Frameworks that Facilitate RAG** section.

Local-first RAG pipeline that ingests PDFs, EPUBs, and Word docs into a searchable index, exposed via an MCP server that returns chunks with page-and-section citations. Differentiates by being end-to-end local — ingestion, embeddings, and retrieval all run on the user's machine; the LLM layer is BYO (cloud or local).

Format: appended to the Frameworks list, matching existing entry style (link + colon + one-sentence description).