### PR TITLE
Add rageval-ai to RAG evaluation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ These tools can assist in evaluating the performance of your RAG system, from tr
 - **[LangFuse](https://github.com/langfuse/langfuse)**: Open-source tool for tracking LLM metrics, observability, and prompt management.
 - **[Opik](https://github.com/comet-ml/opik)**: Open-source platform for LLM observability, evaluations, and prompt optimization.
 - **[Ragas](https://docs.ragas.io/en/stable/)**: Framework that helps evaluate RAG pipelines.
+- **[rageval-ai](https://github.com/CYBki/llm-evaluation)**: "Three-line RAG evaluation library with LLM-as-judge. Works with any OpenAI-compatible endpoint (OpenRouter, Azure, Ollama, vLLM). Two-stage judge for cost-efficient hallucination detection."
 - **[WFGY Problem Map](https://github.com/onestardao/WFGY/tree/main/ProblemMap)**: 16-mode checklist for diagnosing RAG and LLM failures.
 - **[LangSmith](https://docs.smith.langchain.com/)**: A platform for building production-grade LLM applications, allows you to closely monitor and evaluate your application.
 - **[Hugging Face Evaluate](https://github.com/huggingface/evaluate)**: Tool for computing metrics like BLEU and ROUGE to assess text quality.


### PR DESCRIPTION
## What

Adding `rageval-ai` to the RAG evaluation tools list.

## Why it fits this list

- Active on PyPI: https://pypi.org/project/rageval-ai/
- MIT licensed, open source: https://github.com/CYBki/llm-evaluation
- Distinct from existing entries (e.g. Ragas):
  - Single runtime dependency (`httpx` only) — no LangChain / datasets / pandas required
  - Bring-your-own LLM endpoint (OpenAI, OpenRouter, Azure, Anthropic, vLLM, Ollama)
  - Two-stage judge architecture for cost-efficient evaluation
- Twelve metrics: faithfulness, hallucination, answer relevancy, context precision/recall, plus six quality dimensions
- Has CI, type hints, and runnable examples for LangChain + LlamaIndex

## Checklist

- [x] Entry placed in the correct section
- [x] Alphabetical order preserved
- [x] One-line description following the list's conventions
- [x] No other changes in the diff

Happy to adjust wording or position if you prefer.
