### PR TITLE
Add LangGraph + Qdrant hybrid RAG example to Python Tutorials & Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ RAG addresses a fundamental limitation of LLMs: their static knowledge cutoff an
 - [LangChain RAG Tutorial](https://python.langchain.com/docs/use_cases/question_answering/): Comprehensive guide to building RAG applications
 - [LlamaIndex RAG Tutorial](https://docs.llamaindex.ai/en/stable/getting_started/starter_example/): Getting started with LlamaIndex for RAG
 - [Haystack RAG Pipeline](https://docs.haystack.deepset.ai/docs/retrieval-augmented-generation): Building RAG pipelines with Haystack
+- [LangGraph + Qdrant hybrid RAG example](https://github.com/RenanMiqueloti/rag-chatbot): LangGraph pipeline (retrieve → rerank → generate) with BM25 + dense + RRF fusion, FlashRank cross-encoder, FastAPI streaming, and an LLM-as-judge eval harness.
 
 #### Production & Best Practices
 


### PR DESCRIPTION
Adds a LangGraph + Qdrant hybrid-retrieval example to the Python
Tutorials & Examples list.

The repository implements a RAG pipeline as a LangGraph state graph
(retrieve → rerank → generate) with BM25 + dense semantic retrieval
fused via Reciprocal Rank Fusion, FlashRank cross-encoder re-ranking
(with graceful fallback when not installed), FastAPI with `/query` and
`/stream` endpoints, and an LLM-as-judge eval harness scoring
relevance, faithfulness, and completeness. Providers: OpenAI and
Anthropic.

Fills a gap between the basic LangChain/Chroma demo and the higher-level
framework tutorials — readers looking for a hybrid + re-rank reference
implementation now have a concrete example.