### PR TITLE
Add Dakera — self-hosted MCP agent memory layer for RAG pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
+- [Dakera](https://github.com/dakera-ai/dakera-mcp): Self-hosted MCP-native agent memory server that provides long-term episodic memory grounding for RAG pipelines. Decay-weighted vector recall with BM25+HNSW hybrid retrieval, 83 MCP tools, 87.8% LoCoMo benchmark, RocksDB persistence.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
## Add Dakera to Frameworks that Facilitate RAG

**[Dakera](https://github.com/dakera-ai/dakera-mcp)** is a self-hosted agent memory server that complements RAG pipelines with persistent, session-spanning episodic memory.

### How it fits RAG
Traditional RAG retrieves documents on-demand. Dakera adds a persistent memory layer on top — agents can *store* what they learned in previous sessions and *recall* it with decay-weighted scoring, creating a stateful retrieval system rather than a stateless one.

### Key details
- **83 MCP tools**: store, recall, search, sessions, namespaces, decay config
- **Hybrid retrieval**: BM25 full-text + HNSW vector search (Rust-native)
- **Decay-weighted recall**: older memories fade naturally — prevents context flooding
- **87.8% LoCoMo benchmark** — standardized long-term memory eval
- **RocksDB + HNSW** backend — durable, production-grade
- **Apache-2.0**, fully self-hosted, no external API required
- Multi-SDK: Python, JS, Rust, Go