### PR TITLE
Add TheCrawler to Frameworks that Facilitate RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
+- [TheCrawler](https://github.com/manchittlab/TheCrawler): Open-source TypeScript scraper with LLM-powered structured extraction for RAG ingestion. Returns boilerplate-stripped markdown with heading-aware RAG chunking (h1-h3 boundaries with overlap), JSON-LD parsing, PDF/DOCX text extraction, and structured `errorType` enum for branchable retry logic. Endpoint-agnostic extract() works against any OpenAI-compatible LLM. CLI, npm, REST API, and MCP server.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
TheCrawler is an open-source (AGPL-3.0) scraper purpose-built for RAG ingestion pipelines. Specifically designed for the data-prep stage of RAG.

- Repo: https://github.com/manchittlab/TheCrawler
- npm: `thecrawler@0.1.1`
- MCP Registry: `io.github.manchittlab/thecrawler@0.1.1`

What it brings to RAG specifically:
- **Heading-aware chunking** — markdown chunked at h1-h3 boundaries with configurable overlap, each chunk includes section header context. Feeds straight to a vector DB without further processing.
- **LLM-powered structured extraction** — pass a JSON Schema, get parsed typed data from any OpenAI-compatible endpoint (OpenAI / llama.cpp / vLLM / LM Studio / Ollama). No vendor lock-in.
- **PDF and DOCX parsing** out of the box — common RAG ingestion sources.
- **Structured errors** — `errorType` enum (`dns | timeout | rate-limit | blocked-bot | js-required | http-4xx | http-5xx | parse | network | unknown`) + `retryable` boolean. Pipelines can branch retry logic without regex on error messages.
- **Adaptive Cheerio → Playwright fallback** — only renders JS when the page actually needs it. Cost-efficient for large RAG ingestion runs.

Placed in the Frameworks section after `OpenAgent` (following the existing ordering). Happy to relocate per your preference.