### PR TITLE
Add Local Deep Research to Frameworks that Facilitate RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [LiteLLM](https://docs.litellm.ai/): Unified interface for multiple LLM providers (OpenAI, Anthropic, Hugging Face, Replicate) with logging, monitoring, and cost tracking.
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
+- [Local Deep Research](https://github.com/LearningCircuit/local-deep-research): Local-first deep agentic research framework with multi-source retrieval (web, arXiv, PubMed, private documents) and 20+ research strategies.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
Hi! Adding [Local Deep Research](https://github.com/LearningCircuit/local-deep-research) to the Frameworks section.

It's a production-ready RAG framework that fits alongside the existing entries (LlamaIndex, Haystack, Letta, Agentset, OpenAgent):

- **Multi-source retrieval** — web (SearXNG, Brave), arXiv, PubMed, Semantic Scholar, and private documents
- **20+ research strategies** including a LangGraph agent mode
- **Local-first** — Ollama / llama.cpp / any OpenAI-compatible LLM
- **Production-ready** — Docker + pip install, SQLCipher-encrypted storage, CI/CD with security scanning
- 7.8k stars, MIT licensed, actively maintained

Happy to revise the description if you'd like a shorter or differently-framed version.