### PR TITLE
Add psql_bm25s

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Vector databases are critical components of RAG systems, providing efficient sto
 ### Relational Database Extensions:
 
 - [Pgvector](https://github.com/pgvector/pgvector): An open-source extension for vector similarity search in PostgreSQL.
+- [psql_bm25s](https://github.com/Intelligent-Internet/psql_bm25s): A PostgreSQL extension for BM25-family lexical retrieval, useful for keyword and hybrid retrieval pipelines.
 
 ### Other Database Systems:
 


### PR DESCRIPTION
Adds psql_bm25s to Relational Database Extensions.\n\npsql_bm25s is an Apache-2.0 PostgreSQL extension for BM25-family lexical retrieval, useful for keyword and hybrid retrieval pipelines.