### PR TITLE
Add DocBrain to Frameworks that Facilitate RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
 - [Local Deep Research](https://github.com/LearningCircuit/local-deep-research): Local-first deep agentic research framework with multi-source retrieval (web, arXiv, PubMed, private documents) and 20+ research strategies.
+- [DocBrain](https://github.com/shivama205/DocBrain): Self-hosted RAG framework with built-in RBAC, multi-LLM support (Gemini, OpenAI, Anthropic), and natural-language SQL over tabular data. Zero LangChain/LlamaIndex dependencies; ChromaDB local-first vector store.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
Adds [DocBrain](https://github.com/shivama205/DocBrain) to the **Frameworks that Facilitate RAG** section.

DocBrain is an open-source self-hosted RAG framework for teams that can't send data to third-party APIs. A few things that distinguish it from existing entries in the list:

- **Self-hosted by default** — ChromaDB local vector store; no data leaves your infra
- **Table-Augmented Generation (TAG)** — natural-language SQL over CSVs / Excel, alongside document RAG
- **Built-in RBAC** — three role levels with granular knowledge-base sharing
- **Multi-LLM** — Gemini, OpenAI, Anthropic, swappable via env var
- **No framework lock-in** — zero LangChain / LlamaIndex dependencies
- MIT licensed, Python, ships with Docker Compose for one-command setup

Repo: https://github.com/shivama205/DocBrain