### PR TITLE
feat: add TWZRD Agent Intel to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
 - [Local Deep Research](https://github.com/LearningCircuit/local-deep-research): Local-first deep agentic research framework with multi-source retrieval (web, arXiv, PubMed, private documents) and 20+ research strategies.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz): Trust-scoring MCP server for x402 agents on Solana. Provides free preflight checks plus signed trust receipts via USDC micropayment (<1s settlement), enabling RAG agents to verify tool trustworthiness before committing to a response.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Frameworks that Facilitate RAG** section.

**TWZRD Agent Intel** is a trust-scoring MCP server for x402 agents on Solana. It addresses a real gap in the RAG ecosystem: as RAG systems increasingly use agents that call external tools, verifying tool trustworthiness before committing to a response is critical.

- **MCP endpoint**: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP)
- **Free preflight**: agents can check trust scores at no cost
- **Paid trust receipts**: signed USDC micropayment (<1s settlement via x402) for verified receipts
- **Use case**: RAG agents calling external APIs or other agents can use TWZRD to verify tool identity before including tool output in generated responses

This fits the "Agent Tool Trust Verification" category — a production consideration for agentic RAG pipelines where tool provenance matters.