### PR TITLE
Add altor-vec: browser-native WASM HNSW for client-side RAG retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Vector databases are critical components of RAG systems, providing efficient sto
 ### Vector Search Libraries and Tools:
 
 - [FAISS](https://github.com/facebookresearch/faiss): A library for efficient similarity search and clustering of dense vectors, designed to handle large-scale datasets and optimized for fast retrieval of nearest neighbors.
+- [altor-vec](https://github.com/Altor-lab/altor-vec): 54KB WASM HNSW vector search that runs entirely in the browser. Sub-millisecond latency, no server needed, MIT licensed. Ideal for client-side RAG retrieval.
 
 ## 🚀 Production Considerations
 


### PR DESCRIPTION
**altor-vec** enables the retrieval step of RAG to run entirely in the browser — no server, no vector database infrastructure needed.

- 54KB gzipped WASM, sub-millisecond queries at 10K vectors
- HNSW algorithm (same as Pinecone, Weaviate)
- MIT licensed, works with any embedding model
- Perfect for client-side RAG: local retrieval + optional cloud generation
- GitHub: https://github.com/Altor-lab/altor-vec
- Tutorial: https://altorlab.dev/blog/rag-without-server.html