### PR TITLE
Add lilbee to Frameworks that Facilitate RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
 - [Local Deep Research](https://github.com/LearningCircuit/local-deep-research): Local-first deep agentic research framework with multi-source retrieval (web, arXiv, PubMed, private documents) and 20+ research strategies.
-- [lilbee](https://github.com/tobocop2/lilbee): Local-first applied RAG search engine. It runs and manages local GGUF models itself (a llama-server fleet sized by gguf-parser), ingests your files, code, and crawled web pages, and retrieves with asymmetric query embeddings, vector search, and cross-encoder plus LLM rerankers. Answers are grounded with a context budget, grounded refusal, and file-and-line citations.
+- [lilbee](https://github.com/tobocop2/lilbee): Local-first applied RAG search engine. It runs and manages local GGUF models itself (a llama-server fleet sized by gguf-parser), or uses your existing Ollama or LM Studio if you prefer, and ingests your files, code, and crawled web pages. Retrieval uses asymmetric query embeddings, vector search, and cross-encoder plus LLM rerankers; answers are grounded with a context budget, grounded refusal, and file-and-line citations.
 
 ## 🐍 Python Ecosystem for RAG
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
 - [Local Deep Research](https://github.com/LearningCircuit/local-deep-research): Local-first deep agentic research framework with multi-source retrieval (web, arXiv, PubMed, private documents) and 20+ research strategies.
-- [lilbee](https://lilbee.sh/) ([code](https://github.com/tobocop2/lilbee)): Local-first applied RAG search engine. It runs and manages local GGUF models itself (a llama-server fleet sized by gguf-parser), or uses your existing Ollama or LM Studio if you prefer, and ingests your files, code, and crawled web pages. Retrieval uses asymmetric query embeddings, vector search, and cross-encoder plus LLM rerankers; answers are grounded with a context budget, grounded refusal, and file-and-line citations.
+- [lilbee](https://github.com/tobocop2/lilbee): Local-first applied RAG search engine. It runs and manages local GGUF models itself (a llama-server fleet sized by gguf-parser), or uses your existing Ollama or LM Studio if you prefer, and ingests your files, code, and crawled web pages. Retrieval uses asymmetric query embeddings, vector search, and cross-encoder plus LLM rerankers; answers are grounded with a context budget, grounded refusal, and file-and-line citations.
 
 ## 🐍 Python Ecosystem for RAG
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
 - [Local Deep Research](https://github.com/LearningCircuit/local-deep-research): Local-first deep agentic research framework with multi-source retrieval (web, arXiv, PubMed, private documents) and 20+ research strategies.
-- [lilbee](https://github.com/tobocop2/lilbee): Local-first applied RAG search engine. It runs and manages local GGUF models itself (a llama-server fleet sized by gguf-parser), or uses your existing Ollama or LM Studio if you prefer, and ingests your files, code, and crawled web pages. Retrieval uses asymmetric query embeddings, vector search, and cross-encoder plus LLM rerankers; answers are grounded with a context budget, grounded refusal, and file-and-line citations.
+- [lilbee](https://lilbee.sh/) ([code](https://github.com/tobocop2/lilbee)): Local-first applied RAG search engine. It runs and manages local GGUF models itself (a llama-server fleet sized by gguf-parser), or uses your existing Ollama or LM Studio if you prefer, and ingests your files, code, and crawled web pages. Retrieval uses asymmetric query embeddings, vector search, and cross-encoder plus LLM rerankers; answers are grounded with a context budget, grounded refusal, and file-and-line citations.
 
 ## 🐍 Python Ecosystem for RAG
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ RAG implementations vary in complexity, from simple document retrieval to advanc
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support.
 - [OpenAgent](https://github.com/the-open-agent/openagent): Open-source personal AI assistant platform combining LLMs, RAG knowledge base, and autonomous agent loops with browser-use, shell execution, and MCP tool support.
 - [Local Deep Research](https://github.com/LearningCircuit/local-deep-research): Local-first deep agentic research framework with multi-source retrieval (web, arXiv, PubMed, private documents) and 20+ research strategies.
+- [lilbee](https://github.com/tobocop2/lilbee): Local-first applied RAG search engine. It runs and manages local GGUF models itself (a llama-server fleet sized by gguf-parser), ingests your files, code, and crawled web pages, and retrieves with asymmetric query embeddings, vector search, and cross-encoder plus LLM rerankers. Answers are grounded with a context budget, grounded refusal, and file-and-line citations.
 
 ## 🐍 Python Ecosystem for RAG
 


### PR DESCRIPTION
lilbee is a local-first RAG search engine I've been building, and what makes it a little different from most entries here is that it isn't a framework you assemble, it's the whole stack in a single executable (or a `pip install`): no Docker, no separate vector database, no model server to stand up.

It runs and manages the local GGUF models itself (a llama-server fleet sized by gguf-parser), or uses your existing Ollama or LM Studio, and ingests your files, code, and crawled web pages. The retrieval pipeline is a real one: heading-aware and code-aware chunking, hybrid BM25 plus vector search fused with Reciprocal Rank Fusion, asymmetric query embeddings for instruction-tuned embedders, and reranking with both cross-encoders and LLM rerankers. Generation fits a context budget, refuses when the library has nothing relevant, and every answer carries file-and-line citations.

A fleet manager is coming soon that takes the model side from single-GPU and in-process to a multi-GPU fleet, scaling the whole stack (chat, embedding, vision, reranking) across every GPU in the machine, still one executable.

[Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) powers all of lilbee's document intelligence, and I'm on its open-source team, where I personally contributed support for Markdown, CSV, YAML, JSONL, XML, and other formats.

It sits alongside the end-to-end RAG frameworks already in this section (Haystack, LlamaIndex, Dify, OpenAgent) as a local-first, single-binary applied RAG system.

Site: https://lilbee.sh/ . Code: https://github.com/tobocop2/lilbee . Architecture: https://github.com/tobocop2/lilbee/blob/main/docs/architecture.md . Source-available under the Elastic License 2.0, actively maintained. Thanks for keeping Awesome-RAG curated.
