### PR TITLE
Add rag-interview-system to Learning Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ RAG addresses a fundamental limitation of LLMs: their static knowledge cutoff an
 - [LlamaIndex RAG Tutorial](https://docs.llamaindex.ai/en/stable/getting_started/starter_example/): Getting started with LlamaIndex for RAG
 - [Haystack RAG Pipeline](https://docs.haystack.deepset.ai/docs/retrieval-augmented-generation): Building RAG pipelines with Haystack
 - [RAG Techniques](https://github.com/NirDiamant/RAG_Techniques): A comprehensive open-source collection of advanced Retrieval-Augmented Generation techniques as runnable Jupyter notebooks — chunking strategies, query transformations (HyDE, multi-query), hybrid search, reranking, self-query, parent-child retrieval, graph RAG, multi-hop retrieval, and evaluation
+- [RAG Interview System](https://github.com/ather-techie/rag-interview-system): A RAG-powered interview preparation system with 418 curated Q&A pairs (Basic → Advanced) covering 29 RAG architecture patterns — including Naive, Agentic, Graph, Corrective, Self-RAG, Speculative, Multimodal, RAPTOR, HyDE, FLARE, RAG-Fusion, and more — plus 70 production failure-mode questions on hallucination, retrieval gaps, and context window management
 
 #### Production & Best Practices
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ RAG addresses a fundamental limitation of LLMs: their static knowledge cutoff an
 - [LangChain RAG Tutorial](https://python.langchain.com/docs/use_cases/question_answering/): Comprehensive guide to building RAG applications
 - [LlamaIndex RAG Tutorial](https://docs.llamaindex.ai/en/stable/getting_started/starter_example/): Getting started with LlamaIndex for RAG
 - [Haystack RAG Pipeline](https://docs.haystack.deepset.ai/docs/retrieval-augmented-generation): Building RAG pipelines with Haystack
-- [RAG Techniques](https://github.com/NirDiamant/RAG_Techniques): A comprehensive open-source collection of advanced Retrieval-Augmented Generation techniques as runnable Jupyter notebooks — chunking strategies, query transformations (HyDE, multi-query), hybrid search, reranking, self-query, parent-child retrieval, graph RAG, multi-hop retrieval, and evaluation
-- [RAG Interview System](https://github.com/ather-techie/rag-interview-system): A RAG-powered interview preparation system with 418 curated Q&A pairs (Basic → Advanced) covering 29 RAG architecture patterns — including Naive, Agentic, Graph, Corrective, Self-RAG, Speculative, Multimodal, RAPTOR, HyDE, FLARE, RAG-Fusion, and more — plus 70 production failure-mode questions on hallucination, retrieval gaps, and context window management
+- [RAG Techniques](https://github.com/NirDiamant/RAG_Techniques): A comprehensive open-source collection of advanced Retrieval-Augmented Generation techniques as runnable Jupyter notebooks.
+- [RAG Interview System](https://github.com/ather-techie/rag-interview-system): A RAG-powered interview preparation system with 418 curated Q&A pairs (Basic → Advanced) covering 29 RAG architecture patterns.
 
 #### Production & Best Practices
 


### PR DESCRIPTION
## Add rag-interview-system to Learning Resources

**What:** [rag-interview-system](https://github.com/ather-techie/rag-interview-system) 
is a curated interview prep repository covering:
- 418+ RAG Q&As across beginner to advanced levels
- 29 RAG architectures with diagrams
- 6 production failure modes ( 70 production Q&A)
- System design patterns for LLM applications

**Why it fits:** Complements existing framework/tool entries with 
structured learning material for engineers preparing for RAG interviews 
or deepening their understanding of production RAG systems.