### PR TITLE
Add SOAS English-Uzbek RAG Evaluation benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ These tools can assist in evaluating the performance of your RAG system, from tr
 - **[LangFuse](https://github.com/langfuse/langfuse)**: Open-source tool for tracking LLM metrics, observability, and prompt management.
 - **[Opik](https://github.com/comet-ml/opik)**: Open-source platform for LLM observability, evaluations, and prompt optimization.
 - **[Ragas](https://docs.ragas.io/en/stable/)**: Framework that helps evaluate RAG pipelines.
-- **[SOAS English-Uzbek RAG Evaluation](https://github.com/rajantripathi/soas-rag-evaluation)**: Bilingual EN/UZ retrieval-evaluation benchmark for culturally grounded RAG; targeted Uzbek corpus supplementation improved retrieval recall from 39% to 98% in the source study.
+- **[SOAS English-Uzbek RAG Evaluation](https://github.com/rajantripathi/soas-rag-evaluation)**: Bilingual EN/UZ retrieval-evaluation benchmark for culturally grounded RAG systems.
 - **[WFGY Problem Map](https://github.com/onestardao/WFGY/tree/main/ProblemMap)**: 16-mode checklist for diagnosing RAG and LLM failures.
 - **[LangSmith](https://docs.smith.langchain.com/)**: A platform for building production-grade LLM applications, allows you to closely monitor and evaluate your application.
 - **[Hugging Face Evaluate](https://github.com/huggingface/evaluate)**: Tool for computing metrics like BLEU and ROUGE to assess text quality.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ These tools can assist in evaluating the performance of your RAG system, from tr
 - **[LangFuse](https://github.com/langfuse/langfuse)**: Open-source tool for tracking LLM metrics, observability, and prompt management.
 - **[Opik](https://github.com/comet-ml/opik)**: Open-source platform for LLM observability, evaluations, and prompt optimization.
 - **[Ragas](https://docs.ragas.io/en/stable/)**: Framework that helps evaluate RAG pipelines.
+- **[SOAS English-Uzbek RAG Evaluation](https://github.com/rajantripathi/soas-rag-evaluation)**: Bilingual EN/UZ retrieval-evaluation benchmark for culturally grounded RAG; targeted Uzbek corpus supplementation improved retrieval recall from 39% to 98% in the source study.
 - **[WFGY Problem Map](https://github.com/onestardao/WFGY/tree/main/ProblemMap)**: 16-mode checklist for diagnosing RAG and LLM failures.
 - **[LangSmith](https://docs.smith.langchain.com/)**: A platform for building production-grade LLM applications, allows you to closely monitor and evaluate your application.
 - **[Hugging Face Evaluate](https://github.com/huggingface/evaluate)**: Tool for computing metrics like BLEU and ROUGE to assess text quality.


### PR DESCRIPTION
Adds the SOAS English-Uzbek RAG Evaluation benchmark to the Metrics & Evaluation section.

This is a public bilingual EN/UZ retrieval-evaluation benchmark for culturally grounded RAG systems. It is retrieval-focused: systems are evaluated against source-document IDs, which makes it useful for diagnosing whether failures come from corpus coverage or downstream generation.

Headline result from the source study: targeted Uzbek corpus supplementation improved retrieval recall from 39% to 98%.

Source repository: https://github.com/rajantripathi/soas-rag-evaluation
